### PR TITLE
Added params option for the custom fields

### DIFF
--- a/src/Resources/Locations/CustomField.php
+++ b/src/Resources/Locations/CustomField.php
@@ -15,9 +15,9 @@ class CustomField implements CustomFieldContract
     /**
      * {@inheritDoc}
      */
-    public function list(string $locationId): array|string
+    public function list(string $locationId, array $params = []): array|string
     {
-        $payload = Payload::get("locations/{$locationId}/customFields");
+        $payload = Payload::get("locations/{$locationId}/customFields", $params);
 
         return $this->transporter->requestObject($payload)->get('customFields');
     }


### PR DESCRIPTION
GHL allows you to request different model types for the custom fields like contact, opportunity or all. Currently the way it was setup it only returned the contact custom fields which is the default. With this you can at least ask for "all" or "opportunity" only if you desire.