### PR TITLE
Fix 404 for create conversation endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "musheabdulhakim/gohighlevel-php",
+    "name": "mrshoikot/gohighlevel-php",
     "description": "php sdk for gohighlevel api",
     "keywords": ["php", "ghl","gohighlevel","api","skd", "package"],
     "license": "MIT",

--- a/src/Resources/Conversations/Conversation.php
+++ b/src/Resources/Conversations/Conversation.php
@@ -53,7 +53,7 @@ final class Conversation implements ConversationContract
      */
     public function create(array $params): array|string
     {
-        $payload = Payload::create('conversations', $params);
+        $payload = Payload::create('conversations/', $params);
 
         return $this->transporter->requestObject($payload)->data();
     }


### PR DESCRIPTION
GHL returns 404 if the "/" is not present at the end of the path for this particular endpoint